### PR TITLE
Refactor to add stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ $ npm install --global chevalvert/ppmm-builder
 ppmm-builder
 
 Usage:
-  ppmm-builder file.geojson --stylesheet=<style.json>
-  ppmm-builder file.geojson --stylesheet=<style.json> --output=<dir>
-  ppmm-builder file.geojson --stylesheet=<style.json> --output=<dir> --zoom 3
+  cat file.geojson | ppmm-builder --stylesheet=<style.json>
+  cat *.geojson | ppmm-builder --stylesheet=<style.json>
+  ppmm-builder --input file.geojson --stylesheet=<style.json>
+  ppmm-builder --input file.geojson --stylesheet=<style.json> --output=<dir>
+  ppmm-builder --input file.geojson --stylesheet=<style.json> --output=<dir> --zoom 3
   ppmm-builder --help
   ppmm-builder --version
 
@@ -27,9 +29,14 @@ Required:
 Options:
   -h, --help       Show this screen
   -v, --version    Print the current version
-  --porcelain      Make sure the output is parsable
 
+  -i, --input      DEfine the geojson file used as input stream (default: stdin)
   -o, --output     Define the output directory (default: CWD)
+
+  --porcelain      Make sure the output is parsable
+  --verbose        Log additional informations (not compatible with --porcelain)
+  --progress       Log rendering progress (not compatible with --porcelain)
+
   --tile-size      Set the default size of a tile in pixels (default: 256)
   --background-color
                    Set the background color of each tile (default: transparent)

--- a/bin/USAGE
+++ b/bin/USAGE
@@ -1,7 +1,9 @@
 Usage:
-  ppmm-builder file.geojson --stylesheet=<style.json>
-  ppmm-builder file.geojson --stylesheet=<style.json> --output=<dir>
-  ppmm-builder file.geojson --stylesheet=<style.json> --output=<dir> --zoom 3
+  cat file.geojson | ppmm-builder --stylesheet=<style.json>
+  cat *.geojson | ppmm-builder --stylesheet=<style.json>
+  ppmm-builder --input file.geojson --stylesheet=<style.json>
+  ppmm-builder --input file.geojson --stylesheet=<style.json> --output=<dir>
+  ppmm-builder --input file.geojson --stylesheet=<style.json> --output=<dir> --zoom 3
   ppmm-builder --help
   ppmm-builder --version
 
@@ -11,9 +13,14 @@ Required:
 Options:
   -h, --help       Show this screen
   -v, --version    Print the current version
-  --porcelain      Make sure the output is parsable
 
+  -i, --input      DEfine the geojson file used as input stream (default: stdin)
   -o, --output     Define the output directory (default: CWD)
+
+  --porcelain      Make sure the output is parsable
+  --verbose        Log additional informations (not compatible with --porcelain)
+  --progress       Log rendering progress (not compatible with --porcelain)
+
   --tile-size      Set the default size of a tile in pixels (default: 256)
   --background-color
                    Set the background color of each tile (default: transparent)

--- a/lib/abstractions/AABB.js
+++ b/lib/abstractions/AABB.js
@@ -55,7 +55,7 @@ module.exports = class AABB {
     this.center = [this.xmin + this.width / 2, this.ymin + this.height / 2]
   }
 
-  transform (x, y, width, height, {
+  transform ([x, y, width, height], {
     preserveAspectRatio = true,
     padding = 0,
     precision = 5

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,16 @@
 const path = require('path')
+
+const { inspect } = require('util')
 const { createCanvas } = require('canvas')
+
 const project = require('geojson-project')
 const rewind = require('@mapbox/geojson-rewind')
+
 const AABB = require('./abstractions/AABB')
 const Style = require('./abstractions/Style')
-const crop = require('./utils/canvas-crop')
+const tile = require('./utils/canvas-tile')
+const streamGeoJson = require('./utils/stream-geojson')
 
-const STYLES = {}
 const RENDERERS = {
   'LineString': require('./renderers/LineString'),
   'MultiLineString': require('./renderers/MultiLineString'),
@@ -16,13 +20,11 @@ const RENDERERS = {
   'Polygon': require('./renderers/Polygon')
 }
 
-const NO_GEOM = []
-const NO_COORDS = []
-const NO_RENDERER = []
 const NO_STYLE = []
 
-module.exports = async (geojson, stylesheet = {}, {
+module.exports = async (input, stylesheet = {}, {
   verbose = false,
+  progress = false,
   tileSize = 256, // px
   boundingBox = undefined, // follows geographic standard of [xmin, ymax, xmax, ymin]
   backgroundColor = 'transparent',
@@ -34,37 +36,12 @@ module.exports = async (geojson, stylesheet = {}, {
   output = process.cwd(),
   filename = (x, y, zoom) => `${x}-${y}-${zoom}`
 } = {}) => {
-  if (!geojson) throw new Error('No GeoJson string given')
-
-  // Filter out features with a `hidden: true` property
-  geojson.features = geojson.features.filter(feature => !feature.properties || !feature.properties.hidden)
-
-  // Make sure geojson polygons respects the right-hand-rule, as it will be
-  // needed to perform intersections and fill tests
-  geojson = rewind(geojson)
-
-  const size = tileSize * (2 ** zoom)
-  // If a boundingBox is passed, use it in priority, so that user can define a
-  // custom crop if needed. If no boundingBox is passed, check in geojson if a
-  // bbox property exists, and fallback to computing bbox extend itself if none
-  const aabb = boundingBox
-    ? AABB.fromGeoBB(boundingBox)
-    : geojson.bbox
-      ? AABB.fromGeoBB(geojson.bbox)
-      : AABB.fromGeoJson(geojson)
-
-  // Normalize all coordinates to canvas coordinates
-  geojson = project(geojson, aabb.transform(0, 0, size, size, {
-    preserveAspectRatio: true,
-    precision,
-    padding
-  }))
-
-  const STYLE_PROPERTY_NAME = stylesheet['__property'] || 'style'
-  Object.entries(stylesheet).forEach(([name, style]) => {
-    STYLES[name] = new Style(style, { root })
+  Object.entries(stylesheet).forEach(([name, raw]) => {
+    stylesheet[name] = new Style(raw, { root })
   })
 
+  const size = tileSize * (2 ** zoom)
+  const rect = [0, 0, size, size]
   const canvas = createCanvas(size, size)
   const ctx = canvas.getContext('2d')
   ctx.quality = quality
@@ -74,41 +51,54 @@ module.exports = async (geojson, stylesheet = {}, {
     ctx.fillRect(0, 0, canvas.width, canvas.height)
   }
 
-  geojson.features.forEach(render)
+  let aabb = boundingBox && AABB.fromGeoBB(boundingBox)
+
+  await streamGeoJson(input, {
+    validate: feature => feature.geometry && feature.geometry.coordinates,
+    filter: feature => !feature.properties || !feature.properties.hidden,
+    transform: (feature, bbox) => {
+      // If no initial bounding box given, we instanciate one asap with the bbox
+      // constructed during early stream (see stream-geojson bbox object)
+      if (!aabb) {
+        if (!bbox || !bbox.length) throw new Error('No bounding-box given, and no bbox found in GeoJson stream')
+        aabb = AABB.fromGeoBB(bbox)
+      }
+
+      // Make sure geojson polygons respects the right-hand-rule, as it will be
+      // needed to perform intersections and fill tests
+      feature = rewind(feature)
+
+      // Normalize all coordinates to canvas coordinates
+      feature = project(feature, aabb.transform(rect, { precision, padding }))
+
+      return feature
+    },
+    callback: render
+  })
 
   // Chunk the main canvas into smaller tiles and write them to files
-  const files = []
-  for (let j = 0; j < 2 ** zoom; j++) {
-    for (let i = 0; i < 2 ** zoom; i++) {
-      const file = filename(i, j, zoom) + '.png'
-      const rect = [i * tileSize, j * tileSize, tileSize, tileSize]
-
-      verbose && console.time(file)
-      files.push(await crop(canvas, path.join(output, file), rect, { quality }))
-      verbose && console.timeEnd(file)
-    }
-  }
+  const files = await tile(canvas, {
+    tileLength: 2 ** zoom,
+    tileSize,
+    verbose,
+    quality,
+    filePattern: (i, j) => path.join(output, filename(i, j, zoom) + '.png')
+  })
 
   if (verbose) {
     console.log('')
-    NO_GEOM.length && console.error(`NO_GEOM(${NO_GEOM.length}):\nSome features have been skipped because they did not have geometry.\n`)
-    NO_COORDS.length && console.error(`NO_COORDS(${NO_COORDS.length}):\nSome features have been skipped because they did not have geometry coordinates.\n`)
-    NO_RENDERER.length && console.error(`NO_RENDERER(${NO_RENDERER.length}):\nSome features have been skipped because they did not have a renderer.\n`)
     NO_STYLE.length && console.error(`NO_STYLE(${NO_STYLE.length}):\nSome features have been skipped because they did not have a style associated to them.\n`)
   }
 
   return {
     files,
-    warnings: { NO_GEOM, NO_COORDS, NO_RENDERER, NO_STYLE }
+    warnings: { NO_STYLE }
   }
 
-  function render (feature) {
-    if (feature.properties && feature.properties.hidden) return
-    if (!feature.geometry) return NO_COORDS.push(feature)
-    if (!feature.geometry.coordinates) return NO_GEOM.push(feature)
-    if (!RENDERERS.hasOwnProperty(feature.geometry.type)) return NO_RENDERER.push(feature)
+  function render (feature, index) {
+    progress && console.log('Rendering feature', index, '\n', inspect(feature, { colors: true, depth: 1 }))
 
-    const style = (STYLES[feature.properties && feature.properties[STYLE_PROPERTY_NAME]]) || STYLES['__default']
+    const style = getStyle(feature)
     if (!style) return NO_STYLE.push(feature)
     if (style.hidden) return
 
@@ -116,5 +106,11 @@ module.exports = async (geojson, stylesheet = {}, {
     style.apply(ctx)
     RENDERERS[feature.geometry.type].bind(feature)({ ctx, style })
     ctx.restore()
+  }
+
+  function getStyle (feature) {
+    const styleSelectorProperty = stylesheet['__property'] || 'style'
+    const key = feature.properties && feature.properties[styleSelectorProperty]
+    return stylesheet[key] || stylesheet['__default']
   }
 }

--- a/lib/utils/canvas-tile.js
+++ b/lib/utils/canvas-tile.js
@@ -1,0 +1,23 @@
+const crop = require('./canvas-crop')
+
+module.exports = async (canvas, {
+  tileLength = 1,
+  tileSize = 256,
+  verbose = false,
+  quality = 'best',
+  filePattern = (i, j) => `${i}-${j}.png`
+} = {}) => {
+  const files = []
+  for (let j = 0; j < tileLength; j++) {
+    for (let i = 0; i < tileLength; i++) {
+      const filepath = filePattern(i, j)
+      const rect = [i * tileSize, j * tileSize, tileSize, tileSize]
+
+      verbose && console.time(filepath)
+      files.push(await crop(canvas, filepath, rect, { quality }))
+      verbose && console.timeEnd(filepath)
+    }
+  }
+
+  return files
+}

--- a/lib/utils/stream-geojson.js
+++ b/lib/utils/stream-geojson.js
@@ -1,0 +1,50 @@
+const { chain } = require('stream-chain')
+const { parser } = require('stream-json')
+const { pick } = require('stream-json/filters/Pick')
+const { streamArray } = require('stream-json/streamers/StreamArray')
+
+module.exports = (geoJSONStream, {
+  validate = feature => true,
+  filter = feature => true,
+  transform = feature => feature,
+  callback = function () {}
+} = {}) => new Promise((resolve, reject) => {
+  // NOTE: the bbox.value is initially empty as we do not know yet if a bbox is
+  // present in the stream.
+  // During the stream, and especially at early stage, bbox will try and steal
+  // data from the main pipeline to build itself upon completion. It will use
+  // any numeric value it will find on the first 4 indexes, which should be the
+  // bbox (see `pick({ filter })` in the pipeline).
+  // Once built, it will act as a passthrough pipe for the data.
+  const bbox = {
+    value: [],
+    complete: false,
+    steal: function (data) {
+      if (this.complete) return data
+      if (data.key > 4) return data
+      if (typeof data.value !== 'number') return data
+
+      this.value.push(data.value)
+      if (this.value.length === 4) this.complete = true
+    }
+  }
+
+  const pipeline = chain([
+    geoJSONStream,
+    parser({ jsonStreaming: true }),
+    // Cherry pick only chunk after bbox and features keys
+    pick({ filter: stack => stack[0] === 'bbox' || stack[0] === 'features' }),
+    streamArray(),
+    // bbox doing its thing, nothing to see here, move along…
+    data => bbox.steal(data),
+    data => (validate(data.value) && filter(data.value))
+      ? transform(data.value, bbox.value)
+      : null
+  ])
+
+  let index = 0
+  pipeline.on('data', feature => callback(feature, ++index))
+
+  pipeline.on('end', resolve)
+  pipeline.on('error', reject)
+})

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "point-in-polygon": "^1.0.1",
     "polylabel": "^1.0.2",
     "simplify-path": "^1.1.0",
+    "stream-chain": "^2.2.1",
+    "stream-json": "^1.3.3",
     "tmp": "^0.1.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -18,10 +18,12 @@ const options = {
   try {
     console.time(pkg.name)
 
-    const geojson = await fs.readJson(path.join(__dirname, 'sample.geojson'), 'utf8')
-    const stylesheet = await fs.readJson(path.join(__dirname, 'style.json'), 'utf8')
+    const { files, warnings } = await build(
+      fs.createReadStream(path.join(__dirname, 'sample.geojson')),
+      await fs.readJson(path.join(__dirname, 'style.json'), 'utf8'),
+      options
+    )
 
-    const { files, warnings } = await build(geojson, stylesheet, options)
     console.timeEnd(pkg.name)
 
     Object.entries(warnings).forEach(([flag, values]) => {

--- a/test/sample.geojson
+++ b/test/sample.geojson
@@ -4,7 +4,7 @@
   "features": [
     {
       "type": "Feature",
-      "properties": { "hidden": false, "style": "POINT" },
+      "properties": { "hidden": true, "style": "POINT" },
       "geometry": {
         "type": "Point",
         "coordinates": [4e6, -2e6]
@@ -18,7 +18,7 @@
       }
     }, {
       "type": "Feature",
-      "properties": { "hidden": false, "style": "LINESTRING" },
+      "properties": { "hidden": true, "style": "LINESTRING" },
       "geometry": {
         "type": "Polygon",
         "coordinates": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,18 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+stream-chain@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.1.tgz#e6efdee89eef81481d888181ca175f3abe03f396"
+  integrity sha512-LW24AKjJHBrihU8xGLPs/o7OSCNPzBpJ/5JtjMyt8/1WLzcSIRKRRvugeBQjTCFJMn0nFzvN0rd6oCSWguKmxw==
+
+stream-json@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.3.3.tgz#c42750ac4beb124dc6c8aa2f47032f8328aada2a"
+  integrity sha512-i+9XalONBFghoAVUHgg9ag0HvAbyu98rCfB/dtFFrNCxBk3Cdb3GvveeH5Xt/ChkT3I787J8/mMpKq47rPcH8w==
+  dependencies:
+    stream-chain "^2.2.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"


### PR DESCRIPTION
Parsing huge geojson files was problematic and crashed the process in some cases.

This PR introduces a refactor of the main function to handle `ReadableStream` instead of json `String`.

## Working with streams
It is now possible to do 
```console
$ cat file.geojson | ppmm-builder --stylesheet style.json
$ cat *.geojson | ppmm-builder --stylesheet style.json
```
Alternatively, a `-i,--input` arg can be used as well:  
```console
$ ppmm-builder --input file.geojson --stylesheet style.json
```

A `--progress` flag is also introduced to log informations about the feature currently being rendered.

## Bounding box

Bounding box computation support has been dropped for now as it is incompatible with the way streams work. The method `<AABB>.fromGeoJson` still exists though, and support for bbox computation may be re-introduced in a later stage under a `--compute-bbox` flag.

**It is now mandatory to either pass a `--bbox='east,south,west,north'` value or use a geojson stream with a `bbox` property.**

## Minor changes
Some minor changes was introduced to improve code readability and discoverability:
- `<AABB>.transform` method now takes a single array as destination rectangle for mapping instead of four separate values.
- Canvas final tiling is now done via `utils/canvas-tile.js`
- As the geojson streaming pipeline introduces better validation and filtering, a lot of previous warnings are now useless, and have been removed.